### PR TITLE
[김규남]장바구니 미션 구현

### DIFF
--- a/src/main/java/codesquad/domain/AuditorEntity.java
+++ b/src/main/java/codesquad/domain/AuditorEntity.java
@@ -1,0 +1,32 @@
+package codesquad.domain;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+/**
+ * 카트를 추가, 삭제한 경우의 시점을 체크하기 위해 추가
+ */
+@MappedSuperclass
+@EntityListeners(value = { AuditingEntityListener.class })
+public abstract class AuditorEntity {
+    @Column(nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdDate;
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public LocalDateTime getLastModifiedDate() {
+        return lastModifiedDate;
+    }
+}
+

--- a/src/main/java/codesquad/domain/CartItem.java
+++ b/src/main/java/codesquad/domain/CartItem.java
@@ -4,7 +4,7 @@ import javax.persistence.*;
 import java.util.Objects;
 
 @Entity
-public class CartItem extends AuditorEntity{
+public class CartItem {
     @Id
     @GeneratedValue
     private Long id;

--- a/src/main/java/codesquad/domain/CartItem.java
+++ b/src/main/java/codesquad/domain/CartItem.java
@@ -1,0 +1,65 @@
+package codesquad.domain;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Entity
+public class CartItem extends AuditorEntity{
+    @Id
+    @GeneratedValue
+    private Long id;
+    //실제 존재하는 상품에 대한 연관관계 가짐
+    @ManyToOne(fetch = FetchType.EAGER)
+    private Product product;
+    //실제 유저에 대한 연관관계 가짐
+    @ManyToOne(fetch = FetchType.EAGER)
+    private User user;
+    //실제 카트에 있는 상품을 구매하는 경우 true로 변경
+    private boolean isBuy = false;
+    //취소되는 경우 isCancel true로 변경
+    private boolean isCancel = false;
+    private int amount = 0;
+
+    public CartItem() {
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public void setProduct(Product product) {
+        this.product = product;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public void addAmount(int amount) {
+        this.amount += amount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CartItem cartItem = (CartItem) o;
+        return isBuy == cartItem.isBuy &&
+                Objects.equals(id, cartItem.id) &&
+                Objects.equals(product, cartItem.product) &&
+                Objects.equals(user, cartItem.user);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, product, user, isBuy);
+    }
+}

--- a/src/main/java/codesquad/domain/CartItemHistory.java
+++ b/src/main/java/codesquad/domain/CartItemHistory.java
@@ -1,0 +1,21 @@
+package codesquad.domain;
+
+import javax.persistence.*;
+
+@Entity
+public class CartItemHistory extends AuditorEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+    //실제 존재하는 상품에 대한 연관관계 가짐
+    @ManyToOne(fetch = FetchType.EAGER)
+    private Product product;
+    //실제 유저에 대한 연관관계 가짐
+    @ManyToOne(fetch = FetchType.EAGER)
+    private User user;
+    //실제 카트에 있는 상품을 구매하는 경우 true로 변경
+    private boolean isBuy = false;
+    //취소되는 경우 isCancel true로 변경
+    private boolean isCancel = false;
+    private int amount = 0;
+}

--- a/src/main/java/codesquad/domain/CartItemHistoryRepository.java
+++ b/src/main/java/codesquad/domain/CartItemHistoryRepository.java
@@ -1,0 +1,4 @@
+package codesquad.domain;
+
+public class CartItemHistoryRepository {
+}

--- a/src/main/java/codesquad/domain/CartItemRepository.java
+++ b/src/main/java/codesquad/domain/CartItemRepository.java
@@ -1,0 +1,10 @@
+package codesquad.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+    //유저 별 장바구니가 생기기 때문에 유저, 상품으로 조회
+    Optional<CartItem> findByUserAndProduct(User user, Product product);
+}

--- a/src/main/java/codesquad/dto/CartItemDto.java
+++ b/src/main/java/codesquad/dto/CartItemDto.java
@@ -1,0 +1,37 @@
+package codesquad.dto;
+
+import codesquad.domain.CartItem;
+
+import java.io.Serializable;
+
+public class CartItemDto implements Serializable {
+    private Long productId;
+    private int amount;
+
+    public CartItemDto() {
+    }
+
+    public CartItemDto(Long productId) {
+        this.productId = productId;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public void setProductId(Long productId) {
+        this.productId = productId;
+    }
+
+    public CartItem toEntity() {
+        return new CartItem();
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public void setAmount(int amount) {
+        this.amount = amount;
+    }
+}

--- a/src/main/java/codesquad/security/SessionUtils.java
+++ b/src/main/java/codesquad/security/SessionUtils.java
@@ -3,6 +3,7 @@ package codesquad.security;
 import codesquad.domain.User;
 
 import javax.servlet.http.HttpSession;
+import java.util.Optional;
 
 public class SessionUtils {
     public static final String USER_SESSION_KEY = "loginedUser";
@@ -13,6 +14,10 @@ public class SessionUtils {
 
     public static boolean isLoginUser(HttpSession session) {
         return session.getAttribute(USER_SESSION_KEY) != null;
+    }
+
+    public static Optional<User> getLoginUser(HttpSession session) {
+        return Optional.ofNullable((User)session.getAttribute(USER_SESSION_KEY));
     }
 
     public static void removeUserInSession(HttpSession session){

--- a/src/main/java/codesquad/service/CartItemService.java
+++ b/src/main/java/codesquad/service/CartItemService.java
@@ -1,0 +1,32 @@
+package codesquad.service;
+
+import codesquad.domain.*;
+import codesquad.dto.CartItemDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static javafx.beans.binding.Bindings.when;
+
+@Service
+public class CartItemService {
+    @Autowired
+    private CartItemRepository cartRepository;
+    @Autowired
+    private ProductService productService;
+
+    @Transactional
+    public CartItem save(User loginUser, CartItemDto cartItemDto) {
+        Product product = productService.findById(cartItemDto.getProductId());
+        //유저와 상품을 조회해 해당 상품이 이미 장바구니에 들어있으면, 해당 카트 아이템에 삽입한다.
+        //없으면 새로운 장바구니 아이템을 생성한다.
+        CartItem cartItem = cartRepository.findByUserAndProduct(loginUser, product)
+                .orElseGet(() -> new CartItem());
+        cartItem.setProduct(product);
+        cartItem.setUser(loginUser);
+        cartItem.addAmount(cartItemDto.getAmount());
+        return this.cartRepository.save(cartItem);
+    }
+}

--- a/src/main/java/codesquad/service/ProductService.java
+++ b/src/main/java/codesquad/service/ProductService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 public class ProductService {
@@ -17,6 +18,6 @@ public class ProductService {
     }
 
     public Product findById(long id) {
-        return productRepository.findById(id).get();
+        return productRepository.findById(id).orElseThrow(() -> new NoSuchElementException("해당하는 반찬을 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/codesquad/web/ApiUserController.java
+++ b/src/main/java/codesquad/web/ApiUserController.java
@@ -1,16 +1,23 @@
 package codesquad.web;
 
+import codesquad.domain.Product;
 import codesquad.domain.User;
+import codesquad.dto.CartItemDto;
 import codesquad.dto.LoginDTO;
 import codesquad.dto.UserDTO;
 import codesquad.security.SessionUtils;
+import codesquad.service.CartItemService;
+import codesquad.service.ProductService;
 import codesquad.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.annotation.Resource;
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
+import java.util.NoSuchElementException;
 
 @RestController
 @RequestMapping("/users")
@@ -18,6 +25,10 @@ public class ApiUserController {
 
     @Resource(name = "userService")
     private UserService userService;
+    @Autowired
+    private CartItemService cartItemService;
+    @Autowired
+    private ProductService productService;
 
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.OK)
@@ -30,5 +41,11 @@ public class ApiUserController {
     public void login(HttpSession session, @RequestBody LoginDTO loginDTO) {
         User loginUser = userService.login(loginDTO);
         SessionUtils.setUserInSession(session, loginUser);
+    }
+
+    @PostMapping("/add-cart")
+    public ResponseEntity addCart(@RequestBody CartItemDto cartItemDto, HttpSession session) {
+        User user = SessionUtils.getLoginUser(session).orElseThrow(() -> new NoSuchElementException("로그인이 필요합니다."));
+        return ResponseEntity.status(HttpStatus.CREATED).body(cartItemService.save(user, cartItemDto));
     }
 }

--- a/src/main/resources/static/cart.css
+++ b/src/main/resources/static/cart.css
@@ -1,0 +1,4 @@
+.go-to-cart-active {
+    background:#2ac1bc;
+    color: #fff;
+}

--- a/src/main/resources/static/js/cart-list.js
+++ b/src/main/resources/static/js/cart-list.js
@@ -1,0 +1,70 @@
+class CartListManager {
+    constructor() {
+        this.priceSum = 0;
+        this.cartItems = [];
+        this.updateCartItemsInCookie();
+        this.appendCartList();
+        this.updateTotalPrice();
+    }
+
+    updateTotalPrice() {
+        $('#totalPrice').innerHTML = this.priceSum;
+    }
+    updateCartItemsInCookie() {
+        this.cartItems = getCookie('cartList') == '' ? [] : JSON.parse(getCookie('cartList'));
+    }
+
+    appendCartList() {
+        const parent = $('.cart > tbody');
+        const cartList = this.cartItems;
+        let sum = 0;
+        Object.keys(cartList).map(function(objectKey, index) {
+            const cartItem = cartList[objectKey];
+            const productPriceSum = (cartItem.amount * 1) * (cartItem.price * 1);
+            sum += productPriceSum;
+            parent.insertAdjacentHTML('beforeend', `<tr class="cart_prd_list" cart_no="12667557" data-hash="H3FBA" data-subscription-flag="0" data-delivery-limit-periods-flag="0" data-delivery-limit="">
+                    <td>
+                        <label class="custom_checkbox on">
+                            <i class="chk_box"></i>
+                            <input type="checkbox" name="cart_select" class="bf hidden_chk">
+                        </label>
+                    </td>
+                    <td class="thumb">
+                        <a href="/shop/detail.php?hash=H3FBA&amp;cno=30020200">
+                            <img src="${cartItem.imgUrl}">
+                        </a>
+                    </td>
+                    <td class="left">
+                        <p class="title prd_name"><a href="/shop/detail.php?hash=H3FBA&amp;cno=30020200">${cartItem.title}</a></p>
+                        <p class="soldout bf_red" style="display: none;">
+                            <strong class="soldout-text"></strong>
+                        </p>
+                        
+                        <p class="cartItemMessage bf_red" style="display: none;"></p>
+                        <p class="receipt_limit bf_red" style="display: none;">
+                            배송 가능일이 한정되어 있는 상품입니다.
+                            <strong class="limit-date"></strong>
+                        </p>
+                    </td>
+                    <td><span cartdata="" id="productPrice">${cartItem.price}</span>원</td>
+                    <td>
+                        <div class="prd_account">
+                            <label><input type="number" class="buy_cnt" min="1" max="999" value="${cartItem.amount}" data-quantity="1" formnovalidate=""></label>
+                            <span>
+                                <a title="수량 더하기" role="increase" class="up quantity_change">수량 더하기</a>
+                                <a title="수량 빼기" role="decrease" class="down quantity_change">수량 빼기</a>
+                            </span>
+                        </div>
+                        <button type="button" class="btn btn_white quantity_change_confirm">변경</button>
+                    </td>
+                    <td><span cartdata="origin/sum_final_sell_prc" id="sumSalePrice">${productPriceSum}</span>원</td>
+                    <td><span class="once_only bf_red">정기배송 불가</span></td>
+                    <td><a class="ico-delete delete_cart_item" style="cursor:pointer">삭제</a></td>
+                </tr>`);
+        });
+        this.priceSum = sum;
+    }
+}
+
+new CartListManager();
+

--- a/src/main/resources/static/js/cart.js
+++ b/src/main/resources/static/js/cart.js
@@ -1,0 +1,112 @@
+class Cart {
+    constructor() {
+        this.cartItems = [];
+        this.updateCartItemsInCookie();
+        $('#products').addEventListener('click', this.productEventHandler.bind(this));
+    }
+
+    updateCartItemsInCookie() {
+        this.cartItems = getCookie('cartList') == '' ? [] : JSON.parse(getCookie('cartList'));
+        this.updateCart();
+    }
+
+    getCartItemLength() {
+        return Object.keys(this.cartItems).length;
+    }
+
+    activeToCartButton() {
+        $('#go_to_cart').parentElement.classList.remove('empty');
+    }
+
+    disableToCartButton() {
+        $('#go_to_cart').parentElement.classList.add('empty');
+    }
+
+    updateCart() {
+        const length = this.getCartItemLength();
+        if (length !== 0) {
+            $('#cart_display_exist').style.display = 'block';
+            $('#basket-counter').innerHTML = length;
+            this.activeToCartButton();
+        } else {
+            $('#cart_display_none').style.display = 'none';
+            this.disableToCartButton();
+        }
+
+    }
+
+    handleSetProductAmount(target) {
+        const inputCount = target.parentElement.previousElementSibling.children[0];
+        let val = inputCount.value;
+        if (target.className === 'up') {
+            inputCount.value = ++val;
+        } else {
+            if (val <= 1) {
+                return;
+            }
+            inputCount.value = --val;
+        }
+    }
+
+    handlerAddCart(target) {
+        const productId = target.getAttribute('data-id');
+        const title = $(`#product-title-${productId}`).getAttribute('ga_name');
+        const thumbnail = $(`#product-${productId}`).getAttribute('src');
+        let price = $(`.selling-price-${productId}`).childNodes[0].cloneNode(false).data.replace(',', '');
+        const amount = $(`.buy-cnt-${productId}`).value;
+        let cartList = {};
+        if (getCookie('cartList')) {
+            cartList = JSON.parse(getCookie('cartList'));
+        }
+        if (cartList[productId]) {
+            let prevAmount = cartList[productId].amount * 1;
+            cartList[productId].amount = prevAmount + (amount * 1);
+        } else {
+            cartList[productId] = {
+                productId: productId,
+                title: title,
+                amount: amount,
+                imgUrl: thumbnail,
+                price: price,
+            };
+        }
+
+        setCookieHour("cartList", JSON.stringify(cartList), 3);
+        this.updateCartItemsInCookie();
+        $('#basket-counter').innerHTML = this.getCartItemLength();
+        $('#basket-toaster').style.dispaly = "block";
+        fetchManager({
+            url: '/users/add-cart',
+            method: 'POST',
+            headers: {'content-type': 'application/json'},
+            body: JSON.stringify({
+                productId: productId,
+                amount: amount
+            }),
+            onSuccess: this.successCallback,
+            onFailure: this.failCallback
+        });
+    }
+
+    productEventHandler(evt) {
+        evt.preventDefault();
+        let target = evt.target;
+        if (target.tagName === 'A') {
+            this.handleSetProductAmount(target);
+        }
+        if (target.id === 'add-cart' || target.id === 'add-cart-span') {
+            target = target.closest('#add-cart');
+            this.handlerAddCart(target);
+        }
+    }
+
+    successCallback() {
+        console.log('success');
+    }
+
+    failCallback() {
+        console.log('fail or user not logined');
+    }
+}
+
+const cart = new Cart();

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -1,0 +1,25 @@
+//쿠키에서 카트리스트 값을 추출, set하는 함수
+function getCookie(cname){
+    var name = cname + "=";
+    var decodedCookie = decodeURIComponent(unescape(document.cookie));
+    var ca = decodedCookie.split(';');
+    for(var i = 0; i <ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) == ' ') {
+            c = c.substring(1);
+        }
+        if (c.indexOf(name) == 0) {
+            return c.substring(name.length, c.length);
+        }
+    }
+    return "";
+}
+
+
+function setCookieHour( name, value, hours ){
+    var now = new Date();
+    var time = now.getTime();
+    time += 3600 * 1000 * hours;
+    now.setTime(time);
+    document.cookie = name + "=" + escape( value ) + "; path=/; expires=" + now.toUTCString() + ";"
+}

--- a/src/main/resources/static/js/util.js
+++ b/src/main/resources/static/js/util.js
@@ -1,0 +1,22 @@
+function $(selector) {
+    return document.querySelector(selector);
+}
+
+function $All(selector) {
+    return document.querySelectorAll(selector);
+}
+
+function fetchManager({ url, method, body, headers, onSuccess, onFailure}) {
+    fetch(url, {
+        method,
+        body,
+        headers,
+        credentials: "same-origin"
+    }).then((response) => {
+        if(response.ok) {
+            response.json().then((result) => onSuccess(result))
+        } else {
+            onFailure(response);
+        }
+    });
+}

--- a/src/main/resources/templates/base.html
+++ b/src/main/resources/templates/base.html
@@ -11,6 +11,7 @@
     <meta name="naver-site-verification" content="e543b30ae873355f2c556f58b48ae7c95c1cea05">
     <title>배민찬 - 모바일 넘버원 반찬가게</title>
     <link rel="stylesheet" href="/main.css" />
+    <link rel="stylesheet" href="/cart.css" />
     {{#block "header"}}
     {{/block}}
 </head>

--- a/src/main/resources/templates/cart.html
+++ b/src/main/resources/templates/cart.html
@@ -50,60 +50,6 @@
                             </tr>
                         </thead>
                         <tbody>
-
-                            <tr class="cart_prd_list" cart_no="12585780" data-hash="I9D6D" data-subscription-flag="0" data-delivery-limit-periods-flag="1"
-                                data-delivery-limit="2018-07-19~2018-08-15">
-                                <td>
-                                    <label class="custom_checkbox on">
-                                        <i class="chk_box"></i>
-                                        <input type="checkbox" name="cart_select" class="bf hidden_chk">
-                                    </label>
-                                </td>
-                                <td class="thumb">
-                                    <a href="/shop/detail.php?hash=I9D6D&amp;cno=30011800">
-                                        <img src="https://cdn.bmf.kr/_data/product/I9D6D/88bd9878ff327da7adc71a9f81e3488b.jpg">
-                                    </a>
-                                </td>
-                                <td class="left">
-                                    <p class="title prd_name">
-                                        <a href="/shop/detail.php?hash=I9D6D&amp;cno=30011800">[집밥의완성] 공심채볶음 170g</a>
-                                    </p>
-                                    <p class="soldout bf_red" style="display: none;">
-                                        <strong class="soldout-text"></strong>
-                                    </p>
-
-                                    <p class="cartItemMessage bf_red" style="display: none;"></p>
-                                    <p class="receipt_limit bf_red" style="">
-                                        배송 가능일이 한정되어 있는 상품입니다.
-                                        <strong class="limit-date">
-                                            <br>2018-07-19~2018-08-15</strong>
-                                    </p>
-                                </td>
-                                <td>
-                                    <span cartdata="" id="productPrice">5,200</span>원</td>
-                                <td>
-                                    <div class="prd_account">
-                                        <label>
-                                            <input type="number" class="buy_cnt" min="1" max="999" value="4" data-quantity="4"
-                                                formnovalidate="">
-                                        </label>
-                                        <span>
-                                            <a title="수량 더하기" role="increase" class="up quantity_change">수량 더하기</a>
-                                            <a title="수량 빼기" role="decrease" class="down quantity_change">수량 빼기</a>
-                                        </span>
-                                    </div>
-                                    <button type="button" class="btn btn_white quantity_change_confirm">변경</button>
-                                </td>
-                                <td>
-                                    <span cartdata="origin/sum_final_sell_prc" id="sumSalePrice">20,800</span>원</td>
-                                <td>
-                                    <span class="once_only bf_red">정기배송 불가</span>
-                                </td>
-                                <td>
-                                    <a class="ico-delete delete_cart_item" style="cursor:pointer">삭제</a>
-                                </td>
-                            </tr>
-
                         </tbody>
                     </table>
 
@@ -168,4 +114,11 @@
             </div>
         </div>
     </div>
+{{/block}}
+
+<!-- script references -->
+{{#block "footer"}}
+<script src="/js/util.js"></script>
+<script src="/js/common.js"></script>
+<script src="/js/cart-list.js"></script>
 {{/block}}

--- a/src/main/resources/templates/products.html
+++ b/src/main/resources/templates/products.html
@@ -54,7 +54,7 @@
                         {{#products}}
                         <li>
                             <div class="imgthumb">
-	                              <img src="{{imgUrl}}" alt="">
+	                              <img id="product-{{id}}" src="{{imgUrl}}" alt="">
 
                                 <a href="/product/{{id}}" ga_id="17435" ga_name="{{description}}">
                                   <div class="thumb_badge"><span class="num">20</span><span class="unit">%</span></div>
@@ -62,24 +62,24 @@
                             </div>
                             <dl class="prds_lst_info">
                                 <dt class="prd_tlt">
-                                    <a href="/product/{{id}}" ga_id="17435" ga_name="{{description}}">
+                                    <a href="/product/{{id}}" id="product-title-{{id}}" ga_id="17435" ga_name="{{description}}">
                                         <span>{{description}}</span>
                                     </a>
                                 </dt>
                                 <dd class="prd_thumb_price">
-                                    <p class="selling-price">4,640<span class="won">원</span></p>
+                                    <p class="selling-price-{{id}}">4,640<span class="won">원</span></p>
                                     <p class="origin-price"><del>{{price}}원</del></p>
                                 </dd>
                                 <dd class="prd_to_basket">
-                                    <div class="prd_account clearfix">
-                                        <label><input class="buy_cnt" type="text" name="amount" value="1" data-name="{{title}}" data-no="17435" data-price="" data-hash="H62C9" data-min="1" data-max="-1"></label>
+                                    <div class="prd_account clearfix add-count-form">
+                                        <label><input class="buy-cnt-{{id}}" id="amount" type="text" name="amount" value="1" data-name="{{title}}" data-no="17435" data-price="" data-hash="H62C9" data-min="1" data-max="-1"></label>
                                         <span>
                                             <a href="#" title="수량 더하기" class="up">수량 더하기</a>
                                             <a href="#" title="수량 빼기" class="down">수량 빼기</a>
                                         </span>
                                     </div>
-                                    <button class="btn btn_gray prd_thumb_btn cart" data-role="add-to-cart-button" data-hash="H62C9" data-price="4640">
-                                      <span>담기</span>
+                                    <button class="btn btn_gray prd_thumb_btn cart" id="add-cart" data-role="add-to-cart-button" data-hash="H62C9" data-id="{{id}}" data-price="4640">
+                                      <span id="add-cart-span">담기</span>
                                     </button>
                                 </dd>
                             </dl>
@@ -94,10 +94,10 @@
                     </h3>
                     <div class="empty">
                         <p class="top_box_number">
-                            <span class="txt" style="display:;" id="cart_display_none">담은상품이<br>없습니다.</span>
+                            <span class="txt" style="display:none;" id="cart_display_none">담은상품이<br>없습니다.</span>
                             <strong class="number" id="cart_display_exist" style="display:none"><span id="basket-counter" class="number_txt">0</span><span class="unit">개</span></strong>
                         </p>
-                        <a href="/cart" id="go_to_cart" class="go_to_basket">장바구니 이동 <span>&gt;</span></a>
+                        <a href="/cart" id="go_to_cart" class="go_to_basket go-to-cart-active">장바구니 이동 <span>&gt;</span></a>
                     </div>
                     <div id="basket-toaster" class="tooltip" style="display: none;">
                         <i class="tooltip_arr"></i>
@@ -108,4 +108,11 @@
             </div>
         </div>
     </div>
+{{/block}}
+
+<!-- script references -->
+{{#block "footer"}}
+<script src="/js/util.js"></script>
+<script src="/js/common.js"></script>
+<script src="/js/cart.js"></script>
 {{/block}}

--- a/src/test/java/codesquad/service/CartItemServiceTest.java
+++ b/src/test/java/codesquad/service/CartItemServiceTest.java
@@ -1,0 +1,42 @@
+package codesquad.service;
+
+import codesquad.domain.*;
+import codesquad.dto.CartItemDto;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CartItemServiceTest {
+    @Mock
+    private ProductRepository productRepository;
+    @Mock
+    private ProductService productService;
+    @Mock
+    private CartItemRepository cartRepository;
+    @InjectMocks
+    private CartItemService cartItemService;
+    @Test
+    public void createTest() {
+
+
+        CartItem cartItem = new CartItem();
+        User user = new User();
+        Product product = new Product();
+        CartItemDto cartItemDto = new CartItemDto();
+        when(productService.findById(cartItemDto.getProductId())).thenReturn((product));
+        cartItem.setUser(user);
+        cartItem.setProduct(product);
+        cartItemService.save(user, cartItemDto);
+        verify(cartRepository).save(cartItem);
+    }
+
+
+}

--- a/src/test/java/codesquad/service/CartItemServiceTest.java
+++ b/src/test/java/codesquad/service/CartItemServiceTest.java
@@ -8,8 +8,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.Optional;
-
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -25,8 +23,6 @@ public class CartItemServiceTest {
     private CartItemService cartItemService;
     @Test
     public void createTest() {
-
-
         CartItem cartItem = new CartItem();
         User user = new User();
         Product product = new Product();


### PR DESCRIPTION
장바구니 미션 구현

프론트
장바구니 추가 시 쿠키에 장바구니 아이템 정보 저장 추가
쿠키에서 값 get, set하는 함수 구현
쿠키에 있는 카트 리스트를 받아서 리스트에 출력하는 코드 추가

벡엔드
CartItem 엔티티 생성(User와 Product간 연관관계 가짐)
JpaAuditing abstract class 생성, Jpaauditing 설정 추가
CartItem add 서비스, repo 추가
장바구니 아이템 추가 api controller 구현

추후 로그인 시 쿠키값 읽어 db의 회원 장바구니에 동기화하려고 했으나 시간 부족으로 구현하지 못함